### PR TITLE
Fix Burnout's mana consumption

### DIFF
--- a/src/player.cpp
+++ b/src/player.cpp
@@ -674,8 +674,8 @@ std::vector<action::Action> Player::onSpellImpactProc(const State& state, const 
                 actions.push_back(manaAction(mana, "Master of Elements"));
             }
 
-            if (runes.burnout && instance.spell->actual_cost)
-                actions.push_back(manaAction(instance.spell->actual_cost * -0.01, "Burnout"));
+            if (runes.burnout)
+                actions.push_back(manaAction(base_mana * -0.01, "Burnout"));
         }
     }
 


### PR DESCRIPTION
Burnout consumes 1% of the player's base mana regardless of the spell's cost. This can easily be seen with the free missiles from Missile Barrage. Currently, those crits don't consume any mana in the sim.